### PR TITLE
Fix split validation

### DIFF
--- a/Pdf_tool.py
+++ b/Pdf_tool.py
@@ -143,10 +143,14 @@ class PDFToolApp:
             return
 
         try:
-            split_points = sorted(set(int(p.strip()) for p in raw_input.split(",") if p.strip().isdigit()))
+            tokens = [p.strip() for p in raw_input.split(",")]
+            if not tokens or any(not t.isdigit() for t in tokens):
+                raise ValueError
+
+            split_points = sorted({int(t) for t in tokens})
             if not split_points or any(p < 1 or p >= self.page_count for p in split_points):
                 raise ValueError
-        except:
+        except Exception:
             messagebox.showerror("Invalid Input", "Please enter valid page numbers (1 to N-1).")
             return
 


### PR DESCRIPTION
## Summary
- improve page number validation for splitting
- normalize line endings in Pdf_tool.py

## Testing
- `python3 -m py_compile Pdf_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_68608aa52e98832ab13e04466d57f6ea